### PR TITLE
Scalar Type Hints added

### DIFF
--- a/src/Contracts/Requests/ChargeInterface.php
+++ b/src/Contracts/Requests/ChargeInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 /**

--- a/src/Contracts/Requests/CouponInterface.php
+++ b/src/Contracts/Requests/CouponInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 use Bulldog\Strype\Contracts\Resources\CouponDurationInterface;

--- a/src/Contracts/Requests/CustomerInterface.php
+++ b/src/Contracts/Requests/CustomerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 /**

--- a/src/Contracts/Requests/DiscountInterface.php
+++ b/src/Contracts/Requests/DiscountInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 interface DiscountInterface

--- a/src/Contracts/Requests/DisputeInterface.php
+++ b/src/Contracts/Requests/DisputeInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 interface DisputeInterface

--- a/src/Contracts/Requests/EventInterface.php
+++ b/src/Contracts/Requests/EventInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 interface EventInterface

--- a/src/Contracts/Requests/FileInterface.php
+++ b/src/Contracts/Requests/FileInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 use Bulldog\Strype\Contracts\Resources\FilesInterface;

--- a/src/Contracts/Requests/FileLinkInterface.php
+++ b/src/Contracts/Requests/FileLinkInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 interface FileLinkInterface

--- a/src/Contracts/Requests/InvoiceInterface.php
+++ b/src/Contracts/Requests/InvoiceInterface.php
@@ -8,7 +8,7 @@ use Bulldog\Strype\Contracts\Resources\SubscriptionBillingInterface;
 
 interface InvoiceInterface
 {
-    public function create(CustomerInterface $customer, SubscriptionBillingInterface $type, array $arguments = [], string $key = null);
+    public function create(CustomerInterface $customer, SubscriptionBillingInterface $type, array $arguments = [], ?string $key = null);
 
     public function finalizeInvoice(string $invoiceid);
 

--- a/src/Contracts/Requests/InvoiceInterface.php
+++ b/src/Contracts/Requests/InvoiceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 use Bulldog\Strype\Contracts\Resources\SubscriptionBillingInterface;

--- a/src/Contracts/Requests/InvoiceItemInterface.php
+++ b/src/Contracts/Requests/InvoiceItemInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 use Bulldog\Strype\Contracts\Resources\InvoiceItemTypeInterface;

--- a/src/Contracts/Requests/PayoutInterface.php
+++ b/src/Contracts/Requests/PayoutInterface.php
@@ -6,7 +6,7 @@ namespace Bulldog\Strype\Contracts\Requests;
 
 interface PayoutInterface
 {
-    public function create(int $amount, $arguments = [], $key = null, $currency = 'usd');
+    public function create(int $amount, $arguments = [], $key = null, string $currency = 'usd');
 
     public function cancel(string $id);
 }

--- a/src/Contracts/Requests/PayoutInterface.php
+++ b/src/Contracts/Requests/PayoutInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 interface PayoutInterface

--- a/src/Contracts/Requests/ProductInterface.php
+++ b/src/Contracts/Requests/ProductInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 use Bulldog\Strype\Contracts\Resources\ProductTypeInterface;

--- a/src/Contracts/Requests/RefundInterface.php
+++ b/src/Contracts/Requests/RefundInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 interface RefundInterface

--- a/src/Contracts/Requests/SubscriptionInterface.php
+++ b/src/Contracts/Requests/SubscriptionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 use Bulldog\Strype\Contracts\Resources\SubscriptionBillingInterface;

--- a/src/Contracts/Requests/TokenInterface.php
+++ b/src/Contracts/Requests/TokenInterface.php
@@ -6,9 +6,9 @@ namespace Bulldog\Strype\Contracts\Requests;
 
 interface TokenInterface
 {
-    public function createCard($number, $expMonth, $expYear, $cvc, $arguments = [], $key = null);
+    public function createCard($number, int $expMonth, int $expYear, int $cvc, $arguments = [], $key = null);
 
-    public function createBankAccount($country, $currency, $accountHolderName, $accountHolderType, $routingNumber, $accountNumber, $arguments = [], $key = null);
+    public function createBankAccount($country, $currency, string $accountHolderName, $accountHolderType, $routingNumber, $accountNumber, $arguments = [], $key = null);
 
     public function createPii($personalIdNumber, $key = null);
 

--- a/src/Contracts/Requests/TokenInterface.php
+++ b/src/Contracts/Requests/TokenInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Requests;
 
 interface TokenInterface

--- a/src/Contracts/Resources/CouponDurationInterface.php
+++ b/src/Contracts/Resources/CouponDurationInterface.php
@@ -4,5 +4,5 @@ namespace Bulldog\Strype\Contracts\Resources;
 
 interface CouponDurationInterface
 {
-    public function getCouponData();
+    public function getCouponData() : array;
 }

--- a/src/Contracts/Resources/CouponDurationInterface.php
+++ b/src/Contracts/Resources/CouponDurationInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Resources;
 
 interface CouponDurationInterface

--- a/src/Contracts/Resources/CouponTypeInterface.php
+++ b/src/Contracts/Resources/CouponTypeInterface.php
@@ -4,5 +4,5 @@ namespace Bulldog\Strype\Contracts\Resources;
 
 interface CouponTypeInterface
 {
-    public function getCouponType();
+    public function getCouponType() : array;
 }

--- a/src/Contracts/Resources/CouponTypeInterface.php
+++ b/src/Contracts/Resources/CouponTypeInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Resources;
 
 interface CouponTypeInterface

--- a/src/Contracts/Resources/FilesInterface.php
+++ b/src/Contracts/Resources/FilesInterface.php
@@ -6,5 +6,5 @@ interface FilesInterface
 {
     public function getFile();
 
-    public function getPurpose();
+    public function getPurpose() : string;
 }

--- a/src/Contracts/Resources/FilesInterface.php
+++ b/src/Contracts/Resources/FilesInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Resources;
 
 interface FilesInterface

--- a/src/Contracts/Resources/InvoiceItemTypeInterface.php
+++ b/src/Contracts/Resources/InvoiceItemTypeInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Resources;
 
 interface InvoiceItemTypeInterface

--- a/src/Contracts/Resources/ProductTypeInterface.php
+++ b/src/Contracts/Resources/ProductTypeInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Resources;
 
 interface ProductTypeInterface

--- a/src/Contracts/Resources/SubscriptionBillingInterface.php
+++ b/src/Contracts/Resources/SubscriptionBillingInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Resources;
 
 interface SubscriptionBillingInterface

--- a/src/Contracts/Traits/DeleteInterface.php
+++ b/src/Contracts/Traits/DeleteInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Traits;
 
 /**

--- a/src/Contracts/Traits/ListAllInterface.php
+++ b/src/Contracts/Traits/ListAllInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Traits;
 
 interface ListAllInterface

--- a/src/Contracts/Traits/RetrieveInterface.php
+++ b/src/Contracts/Traits/RetrieveInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Traits;
 
 /**

--- a/src/Contracts/Traits/UpdateInterface.php
+++ b/src/Contracts/Traits/UpdateInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Contracts\Traits;
 
 /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype;
 
 /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -26,7 +26,7 @@ abstract class Request
     /**
      * Set the response data as properties on the class.
      */
-    protected function setProperties()
+    protected function setProperties() : void
     {
         // Loop through the response object
         foreach ($this->response->keys() as $key) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -11,7 +11,7 @@ abstract class Request
 
     protected $response;
 
-    public function getId()
+    public function getId() : int
     {
         return $this->id;
     }

--- a/src/Requests/Balance.php
+++ b/src/Requests/Balance.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/Charge.php
+++ b/src/Requests/Charge.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/Coupon.php
+++ b/src/Requests/Coupon.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/Coupon.php
+++ b/src/Requests/Coupon.php
@@ -29,7 +29,7 @@ class Coupon extends Request implements CouponInterface, RetrieveInterface, Upda
         return $this;
     }
 
-    protected function stripe(string $method, $arguments, $idempotencyKey = null)
+    protected function stripe(string $method, $arguments, $idempotencyKey = null) : void
     {
         $this->response = \Stripe\Coupon::{$method}($arguments, [
             'idempotency_key' => $idempotencyKey,

--- a/src/Requests/Customer.php
+++ b/src/Requests/Customer.php
@@ -46,7 +46,7 @@ class Customer extends Request implements CustomerInterface, RetrieveInterface, 
         return $this->id;
     }
 
-    protected function stripe(string $method, $arguments, $idempotencyKey = null)
+    protected function stripe(string $method, $arguments, $idempotencyKey = null) : void
     {
         $this->response = \Stripe\Customer::{$method}($arguments, [
             'idempotency_key' => $idempotencyKey,

--- a/src/Requests/Customer.php
+++ b/src/Requests/Customer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/Discount.php
+++ b/src/Requests/Discount.php
@@ -28,7 +28,7 @@ class Discount extends Request implements DiscountInterface
         return $this;
     }
 
-    protected function customer($id, $idempotencyKey = null)
+    protected function customer($id, $idempotencyKey = null) : void
     {
         $this->response = \Stripe\Customer::retrieve($id, [
             'idempotency_key' => $idempotencyKey,
@@ -36,7 +36,7 @@ class Discount extends Request implements DiscountInterface
         $this->setProperties();
     }
 
-    protected function subscription($id, $idempotencyKey = null)
+    protected function subscription($id, $idempotencyKey = null) : void
     {
         $this->response = \Stripe\Subscription::retrieve($id, [
             'idempotency_key' => $idempotencyKey,

--- a/src/Requests/Discount.php
+++ b/src/Requests/Discount.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/Dispute.php
+++ b/src/Requests/Dispute.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/Dispute.php
+++ b/src/Requests/Dispute.php
@@ -25,7 +25,7 @@ class Dispute extends Request implements DisputeInterface, RetrieveInterface, Up
         return $this;
     }
 
-    protected function stripe(string $method, $arguments)
+    protected function stripe(string $method, $arguments) : void
     {
         $this->response = \Stripe\Dispute::{$method}($arguments);
         $this->setProperties();

--- a/src/Requests/Event.php
+++ b/src/Requests/Event.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/Event.php
+++ b/src/Requests/Event.php
@@ -15,7 +15,7 @@ class Event extends Request implements EventInterface, RetrieveInterface, ListAl
 {
     use Retrieve, ListAll;
 
-    protected function stripe(string $method, $arguments)
+    protected function stripe(string $method, $arguments) : void
     {
         $this->response = \Stripe\Event::{$method}($arguments);
         $this->setProperties();

--- a/src/Requests/File.php
+++ b/src/Requests/File.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/File.php
+++ b/src/Requests/File.php
@@ -26,7 +26,7 @@ class File extends Request implements FileInterface, RetrieveInterface, ListAllI
         return $this;
     }
 
-    protected function stripe(string $method, $arguments, $idempotencyKey = null)
+    protected function stripe(string $method, $arguments, $idempotencyKey = null) : void
     {
         $this->response = \Stripe\File::{$method}($arguments, [
             'idempotency_key' => $idempotencyKey,

--- a/src/Requests/FileLink.php
+++ b/src/Requests/FileLink.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/FileLink.php
+++ b/src/Requests/FileLink.php
@@ -25,7 +25,7 @@ class FileLink extends Request implements FileLinkInterface, RetrieveInterface, 
         return $this;
     }
 
-    protected function stripe(string $method, $arguments, $idempotencyKey = null)
+    protected function stripe(string $method, $arguments, $idempotencyKey = null) : void
     {
         $this->response = \Stripe\FileLink::{$method}($arguments, [
             'idempotency_key' => $idempotencyKey,

--- a/src/Requests/Invoice.php
+++ b/src/Requests/Invoice.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/Invoice.php
+++ b/src/Requests/Invoice.php
@@ -21,7 +21,7 @@ class Invoice extends Request implements InvoiceInterface, RetrieveInterface, Up
 {
     use Retrieve, Update, ListAll, Delete;
 
-    public function create(CustomerInterface $customer, SubscriptionBillingInterface $type, array $arguments = [], string $key = null)
+    public function create(CustomerInterface $customer, SubscriptionBillingInterface $type, array $arguments = [], ?string $key = null)
     {
         $arguments = array_merge($arguments, $type->getBilling());
         $arguments['customer'] = $customer->getCustomerId();

--- a/src/Requests/Invoice.php
+++ b/src/Requests/Invoice.php
@@ -100,7 +100,7 @@ class Invoice extends Request implements InvoiceInterface, RetrieveInterface, Up
         return $this;
     }
 
-    protected function stripe(string $method, $arguments, $idempotencyKey = null)
+    protected function stripe(string $method, $arguments, $idempotencyKey = null) : void
     {
         $this->response = \Stripe\Invoice::{$method}($arguments, [
             'idempotency_key' => $idempotencyKey,

--- a/src/Requests/InvoiceItem.php
+++ b/src/Requests/InvoiceItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/InvoiceItem.php
+++ b/src/Requests/InvoiceItem.php
@@ -31,7 +31,7 @@ class InvoiceItem extends Request implements InvoiceItemInterface, RetrieveInter
         return $this;
     }
 
-    protected function stripe(string $method, $arguments, $idempotencyKey = null)
+    protected function stripe(string $method, $arguments, $idempotencyKey = null) : void
     {
         $this->response = \Stripe\InvoiceItem::{$method}($arguments, [
             'idempotency_key' => $idempotencyKey,

--- a/src/Requests/Payout.php
+++ b/src/Requests/Payout.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/Payout.php
+++ b/src/Requests/Payout.php
@@ -17,7 +17,7 @@ class Payout extends Request implements PayoutInterface, RetrieveInterface, List
 {
     use Retrieve, Update, ListAll;
 
-    public function create(int $amount, $arguments = [], $key = null, $currency = 'usd')
+    public function create(int $amount, $arguments = [], $key = null, string $currency = 'usd')
     {
         $arguments['amount'] = $amount;
         $arguments['currency'] = $currency;

--- a/src/Requests/Payout.php
+++ b/src/Requests/Payout.php
@@ -34,7 +34,7 @@ class Payout extends Request implements PayoutInterface, RetrieveInterface, List
         return $this;
     }
 
-    protected function stripe(string $method, $arguments, $idempotencyKey = null)
+    protected function stripe(string $method, $arguments, $idempotencyKey = null) : void
     {
         $this->response = \Stripe\Payout::{$method}($arguments, [
             'idempotency_key' => $idempotencyKey,

--- a/src/Requests/Product.php
+++ b/src/Requests/Product.php
@@ -27,7 +27,7 @@ class Product extends Request implements ProductInterface, RetrieveInterface, Li
         return $this;
     }
 
-    protected function stripe(string $method, $arguments, $idempotencyKey = null)
+    protected function stripe(string $method, $arguments, $idempotencyKey = null) : void
     {
         $this->response = \Stripe\Product::{$method}($arguments, [
             'idempotency_key' => $idempotencyKey,

--- a/src/Requests/Product.php
+++ b/src/Requests/Product.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/Refund.php
+++ b/src/Requests/Refund.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/Refund.php
+++ b/src/Requests/Refund.php
@@ -26,7 +26,7 @@ class Refund extends Request implements RefundInterface, RetrieveInterface, List
         return $this;
     }
 
-    protected function stripe(string $method, $arguments, $idempotencyKey = null)
+    protected function stripe(string $method, $arguments, $idempotencyKey = null) : void
     {
         $this->response = \Stripe\Refund::{$method}($arguments, [
             'idempotency_key' => $idempotencyKey,

--- a/src/Requests/Subscription.php
+++ b/src/Requests/Subscription.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/Subscription.php
+++ b/src/Requests/Subscription.php
@@ -38,7 +38,7 @@ class Subscription extends Request implements SubscriptionInterface, RetrieveInt
         return $this;
     }
 
-    protected function stripe(string $method, $arguments, $idempotencyKey = null)
+    protected function stripe(string $method, $arguments, $idempotencyKey = null) : void
     {
         $this->response = \Stripe\Subscription::{$method}($arguments, [
             'idempotency_key' => $idempotencyKey,

--- a/src/Requests/Token.php
+++ b/src/Requests/Token.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Requests;
 
 use Bulldog\Strype\Request;

--- a/src/Requests/Token.php
+++ b/src/Requests/Token.php
@@ -57,7 +57,7 @@ class Token extends Request implements TokenInterface, RetrieveInterface
         return $this;
     }
 
-    protected function stripe(string $method, $arguments, $idempotencyKey = null)
+    protected function stripe(string $method, $arguments, $idempotencyKey = null) : void
     {
         $this->response = \Stripe\Token::{$method}($arguments, [
             'idempotency_key' => $idempotencyKey,

--- a/src/Resources/Coupons/Duration/Forever.php
+++ b/src/Resources/Coupons/Duration/Forever.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Coupons\Duration;
 
 use Bulldog\Strype\Contracts\Resources\CouponDurationInterface;

--- a/src/Resources/Coupons/Duration/Forever.php
+++ b/src/Resources/Coupons/Duration/Forever.php
@@ -6,7 +6,7 @@ use Bulldog\Strype\Contracts\Resources\CouponDurationInterface;
 
 class Forever implements CouponDurationInterface
 {
-    public function getCouponData()
+    public function getCouponData() : array
     {
         return ['duration' => 'forever'];
     }

--- a/src/Resources/Coupons/Duration/Once.php
+++ b/src/Resources/Coupons/Duration/Once.php
@@ -6,7 +6,7 @@ use Bulldog\Strype\Contracts\Resources\CouponDurationInterface;
 
 class Once implements CouponDurationInterface
 {
-    public function getCouponData()
+    public function getCouponData() : array
     {
         return ['duration' => 'once'];
     }

--- a/src/Resources/Coupons/Duration/Once.php
+++ b/src/Resources/Coupons/Duration/Once.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Coupons\Duration;
 
 use Bulldog\Strype\Contracts\Resources\CouponDurationInterface;

--- a/src/Resources/Coupons/Duration/Repeating.php
+++ b/src/Resources/Coupons/Duration/Repeating.php
@@ -8,12 +8,12 @@ class Repeating implements CouponDurationInterface
 {
     protected $durationInMonths;
 
-    public function __construct($durationInMonths)
+    public function __construct(int $durationInMonths)
     {
         $this->durationInMonths = $durationInMonths;
     }
 
-    public function getCouponData()
+    public function getCouponData() : array
     {
         return [
             'duration' => 'repeating',

--- a/src/Resources/Coupons/Duration/Repeating.php
+++ b/src/Resources/Coupons/Duration/Repeating.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Coupons\Duration;
 
 use Bulldog\Strype\Contracts\Resources\CouponDurationInterface;

--- a/src/Resources/Coupons/Type/Amount.php
+++ b/src/Resources/Coupons/Type/Amount.php
@@ -9,13 +9,13 @@ class Amount implements CouponTypeInterface
     protected $amount;
     protected $currency;
 
-    public function __construct($amount, $currency = 'usd')
+    public function __construct(int $amount, string $currency = 'usd')
     {
         $this->amount = $amount;
         $this->currency = $currency;
     }
 
-    public function getCouponType()
+    public function getCouponType() : array
     {
         return [
             'amount_off' => $this->amount,

--- a/src/Resources/Coupons/Type/Amount.php
+++ b/src/Resources/Coupons/Type/Amount.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Coupons\Type;
 
 use Bulldog\Strype\Contracts\Resources\CouponTypeInterface;

--- a/src/Resources/Coupons/Type/Percentage.php
+++ b/src/Resources/Coupons/Type/Percentage.php
@@ -8,12 +8,12 @@ class Percentage implements CouponTypeInterface
 {
     protected $percentage;
 
-    public function __construct($percentage)
+    public function __construct(int $percentage)
     {
         $this->percentage = $percentage;
     }
 
-    public function getCouponType()
+    public function getCouponType() : array
     {
         return [
             'percent_off' => $this->percentage,

--- a/src/Resources/Coupons/Type/Percentage.php
+++ b/src/Resources/Coupons/Type/Percentage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Coupons\Type;
 
 use Bulldog\Strype\Contracts\Resources\CouponTypeInterface;

--- a/src/Resources/Files/BusinessLogo.php
+++ b/src/Resources/Files/BusinessLogo.php
@@ -20,7 +20,7 @@ class BusinessLogo implements FilesInterface
         return $this->file;
     }
 
-    public function getPurpose()
+    public function getPurpose() : string
     {
         return $this->purpose;
     }

--- a/src/Resources/Files/BusinessLogo.php
+++ b/src/Resources/Files/BusinessLogo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Files;
 
 use Bulldog\Strype\Contracts\Resources\FilesInterface;

--- a/src/Resources/Files/CustomerSignature.php
+++ b/src/Resources/Files/CustomerSignature.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Files;
 
 use Bulldog\Strype\Contracts\Resources\FilesInterface;

--- a/src/Resources/Files/CustomerSignature.php
+++ b/src/Resources/Files/CustomerSignature.php
@@ -20,7 +20,7 @@ class CustomerSignature implements FilesInterface
         return $this->file;
     }
 
-    public function getPurpose()
+    public function getPurpose() : string
     {
         return $this->purpose;
     }

--- a/src/Resources/Files/DisputeEvidence.php
+++ b/src/Resources/Files/DisputeEvidence.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Files;
 
 use Bulldog\Strype\Contracts\Resources\FilesInterface;

--- a/src/Resources/Files/DisputeEvidence.php
+++ b/src/Resources/Files/DisputeEvidence.php
@@ -20,7 +20,7 @@ class DisputeEvidence implements FilesInterface
         return $this->file;
     }
 
-    public function getPurpose()
+    public function getPurpose() : string
     {
         return $this->purpose;
     }

--- a/src/Resources/Files/IdentityDocument.php
+++ b/src/Resources/Files/IdentityDocument.php
@@ -20,7 +20,7 @@ class IdentityDocument implements FilesInterface
         return $this->file;
     }
 
-    public function getPurpose()
+    public function getPurpose() : string
     {
         return $this->purpose;
     }

--- a/src/Resources/Files/IdentityDocument.php
+++ b/src/Resources/Files/IdentityDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Files;
 
 use Bulldog\Strype\Contracts\Resources\FilesInterface;

--- a/src/Resources/Files/PciDocument.php
+++ b/src/Resources/Files/PciDocument.php
@@ -20,7 +20,7 @@ class PciDocument implements FilesInterface
         return $this->file;
     }
 
-    public function getPurpose()
+    public function getPurpose() : string
     {
         return $this->purpose;
     }

--- a/src/Resources/Files/PciDocument.php
+++ b/src/Resources/Files/PciDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Files;
 
 use Bulldog\Strype\Contracts\Resources\FilesInterface;

--- a/src/Resources/Files/TaxDocumentUserUpload.php
+++ b/src/Resources/Files/TaxDocumentUserUpload.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Files;
 
 use Bulldog\Strype\Contracts\Resources\FilesInterface;

--- a/src/Resources/Files/TaxDocumentUserUpload.php
+++ b/src/Resources/Files/TaxDocumentUserUpload.php
@@ -20,7 +20,7 @@ class TaxDocumentUserUpload implements FilesInterface
         return $this->file;
     }
 
-    public function getPurpose()
+    public function getPurpose() : string
     {
         return $this->purpose;
     }

--- a/src/Resources/InvoiceItems/Amount.php
+++ b/src/Resources/InvoiceItems/Amount.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\InvoiceItems;
 
 use Bulldog\Strype\Contracts\Resources\InvoiceItemTypeInterface;

--- a/src/Resources/InvoiceItems/Quantity.php
+++ b/src/Resources/InvoiceItems/Quantity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\InvoiceItems;
 
 use Bulldog\Strype\Contracts\Resources\InvoiceItemTypeInterface;

--- a/src/Resources/Products/Good.php
+++ b/src/Resources/Products/Good.php
@@ -9,7 +9,7 @@ class Good implements ProductTypeInterface
     protected $name;
     protected $arguments;
 
-    public function __construct($name, array $arguments = [])
+    public function __construct(string $name, array $arguments = [])
     {
         $this->name = $name;
         $this->arguments = $arguments;

--- a/src/Resources/Products/Good.php
+++ b/src/Resources/Products/Good.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Products;
 
 use Bulldog\Strype\Contracts\Resources\ProductTypeInterface;

--- a/src/Resources/Products/Service.php
+++ b/src/Resources/Products/Service.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Products;
 
 use Bulldog\Strype\Contracts\Resources\ProductTypeInterface;

--- a/src/Resources/Products/Service.php
+++ b/src/Resources/Products/Service.php
@@ -9,7 +9,7 @@ class Service implements ProductTypeInterface
     protected $name;
     protected $arguments;
 
-    public function __construct($name, array $arguments = [])
+    public function __construct(string $name, array $arguments = [])
     {
         $this->name = $name;
         $this->arguments = $arguments;

--- a/src/Resources/Subscriptions/ChargeAutomatically.php
+++ b/src/Resources/Subscriptions/ChargeAutomatically.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Subscriptions;
 
 use Bulldog\Strype\Contracts\Resources\SubscriptionBillingInterface;

--- a/src/Resources/Subscriptions/SendInvoice.php
+++ b/src/Resources/Subscriptions/SendInvoice.php
@@ -8,7 +8,7 @@ class SendInvoice implements SubscriptionBillingInterface
 {
     public $daysUntilDue;
 
-    public function __construct($daysUntilDue)
+    public function __construct(int $daysUntilDue)
     {
         $this->daysUntilDue = $daysUntilDue;
     }

--- a/src/Resources/Subscriptions/SendInvoice.php
+++ b/src/Resources/Subscriptions/SendInvoice.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Resources\Subscriptions;
 
 use Bulldog\Strype\Contracts\Resources\SubscriptionBillingInterface;

--- a/src/Strype.php
+++ b/src/Strype.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype;
 
 use Bulldog\Strype\Requests\Balance;

--- a/src/Traits/Delete.php
+++ b/src/Traits/Delete.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Traits;
 
 trait Delete

--- a/src/Traits/ListAll.php
+++ b/src/Traits/ListAll.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Traits;
 
 trait ListAll

--- a/src/Traits/Retrieve.php
+++ b/src/Traits/Retrieve.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Traits;
 
 trait Retrieve

--- a/src/Traits/Update.php
+++ b/src/Traits/Update.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bulldog\Strype\Traits;
 
 trait Update


### PR DESCRIPTION
I made different changes in separate commits so you can choose what commit you don't need.

I made "Declare Strict Types Applied", because it is very helpful for debugging (at least for the first time). I use it in my code permanently now. It is very helpful. (see "Strict Example" part here: https://blog.teamtreehouse.com/5-new-features-php-7)